### PR TITLE
Implemented deregistration logic

### DIFF
--- a/lambdas/stocks-notif/stocks-notif.js
+++ b/lambdas/stocks-notif/stocks-notif.js
@@ -1,6 +1,7 @@
-const { getUsers, getKeys, sendNotifications } = require('push-notif-utils')
+const { getUsers, getKeys, sendNotifications, deregisterSubs } = require('push-notif-utils')
 
 module.exports.handler = async (event) => {
   return await Promise.all([getUsers(), getKeys()])
     .then(sendNotifications)
+    .then(deregisterSubs)
 }

--- a/lambdas/stocks-notif/stocks-notif.js
+++ b/lambdas/stocks-notif/stocks-notif.js
@@ -1,6 +1,6 @@
-const { getSubs, getKeys, sendNotifications } = require('push-notif-utils')
+const { getUsers, getKeys, sendNotifications } = require('push-notif-utils')
 
 module.exports.handler = async (event) => {
-  return await Promise.all([getSubs(), getKeys()])
+  return await Promise.all([getUsers(), getKeys()])
     .then(sendNotifications)
 }

--- a/layer/nodejs/push-notif-utils/deregister-subs.js
+++ b/layer/nodejs/push-notif-utils/deregister-subs.js
@@ -1,0 +1,42 @@
+module.exports = (userNotifs) => {
+  const es = require('aws-es-client')({
+    id: process.env.ES_ID,
+    token: process.env.ES_SECRET,
+    url: process.env.ES_ENDPOINT
+  })
+  return es.bulk({
+    refresh: true,
+    body: getBulkBody(getDeadNotifs(userNotifs))
+  })
+}
+
+function getDeadNotifs (userNotifs) {
+  const filterDeadEndpoint = push => push.status === 'rejected' && push.reason.statusCode === 410
+  const userNotifsWithDeadEndpoints = userNotifs.filter(userNotif => userNotif.value.pushes.filter(filterDeadEndpoint).length > 0)
+  return userNotifsWithDeadEndpoints.map(userNotif => {
+    return {
+      user: userNotif.value.user,
+      deadEndpoints: userNotif.value.pushes.filter(filterDeadEndpoint).map(deadEndpoint => deadEndpoint.reason.endpoint)
+    }
+  })
+}
+
+function getBulkBody (deadNotifs) {
+  return deadNotifs.flatMap(deadNotif => deadNotif.deadEndpoints.flatMap(getOpBodyDuplets(deadNotif.user)))
+}
+
+function getOpBodyDuplets (user) {
+  return deadEndpoint => {
+    const op = { update: { _id: user, _index: 'users'} }
+    const body = {
+      script : {
+        lang: 'painless',
+        source: 'def matchSub; def subs = ctx._source.subscriptions; for (sub in subs) { if (sub.endpoint == params.endpoint) { matchSub = sub; } } subs.remove(subs.indexOf(matchSub))',
+        params: {
+          endpoint: deadEndpoint
+        }
+      }
+    }
+    return [op, body]
+  }
+}

--- a/layer/nodejs/push-notif-utils/deregister-subs.js
+++ b/layer/nodejs/push-notif-utils/deregister-subs.js
@@ -1,13 +1,17 @@
 module.exports = (userNotifs) => {
-  const es = require('aws-es-client')({
-    id: process.env.ES_ID,
-    token: process.env.ES_SECRET,
-    url: process.env.ES_ENDPOINT
-  })
-  return es.bulk({
-    refresh: true,
-    body: getBulkBody(getDeadNotifs(userNotifs))
-  })
+  const deadNotifs = getDeadNotifs(userNotifs)
+  if (deadNotifs.length > 0) {
+    const es = require('aws-es-client')({
+      id: process.env.ES_ID,
+      token: process.env.ES_SECRET,
+      url: process.env.ES_ENDPOINT
+    })
+    return es.bulk({
+      refresh: true,
+      body: getBulkBody(deadNotifs)
+    })
+  }
+  return 'No dead endpoints!'
 }
 
 function getDeadNotifs (userNotifs) {

--- a/layer/nodejs/push-notif-utils/get-users.js
+++ b/layer/nodejs/push-notif-utils/get-users.js
@@ -15,6 +15,5 @@ module.exports = () => {
       }
     }
   })
-    .then(res => res.body.hits.hits)
-    .then(docs => docs.flatMap(doc => doc._source.subscriptions))
+    .then(res => res.body.hits.hits.map(doc => doc._source))
 }

--- a/layer/nodejs/push-notif-utils/send-notifications.js
+++ b/layer/nodejs/push-notif-utils/send-notifications.js
@@ -1,14 +1,60 @@
 const webpush = require('web-push')
 
-module.exports = (res) => {
-  const [subs, keys] = res
+module.exports = (data) => {
+  const [users, keys] = data
   webpush.setVapidDetails(
     'mailto:a.lemaire@klimapartner.de',
     keys.publicKey,
     keys.privateKey
   )
-  const payload = {
-    message: 'Hello World!'
+  return Promise.allSettled(users.map(notifyUser))
+}
+
+function notifyUser (user) {
+  const payload = JSON.stringify({ message: 'Hello World!' })
+  const sendNotif2Sub = sub => webpush.sendNotification(sub, payload).catch(err => err.statusCode === 410 ? deregisterSub(user, sub) : err)
+  return Promise.allSettled(user.subscriptions.map(sendNotif2Sub))
+}
+
+function deregisterSub (user, sub) {
+  const es = require('aws-es-client')({
+    id: process.env.ES_ID,
+    token: process.env.ES_SECRET,
+    url: process.env.ES_ENDPOINT
+  })
+  return es.updateByQuery({
+    index: 'users',
+    refresh: true,
+    body: {
+      script: getScript(sub),
+      query: getQuery(user, sub)
+    }
+  })
+}
+
+function getScript (sub) {
+  return {
+    lang: 'painless',
+    source: 'ctx._source.subscriptions.remove(ctx._source.subscriptions.indexOf(params.sub))',
+    params: {
+      sub: sub
+    }
   }
-  return Promise.all(subs.map(sub => webpush.sendNotification(sub, JSON.stringify(payload))))
+}
+
+function getQuery (user, sub) {
+  return {
+    bool: {
+      must: {
+        match: {
+          _id: user
+        }
+      },
+      filter: {
+        match: {
+          'subscriptions.endpoint': sub.endpoint
+        }
+      }
+    }
+  }
 }

--- a/layer/nodejs/push-notif-utils/send-notifications.js
+++ b/layer/nodejs/push-notif-utils/send-notifications.js
@@ -10,51 +10,10 @@ module.exports = (data) => {
   return Promise.allSettled(users.map(notifyUser))
 }
 
-function notifyUser (user) {
+async function notifyUser (user) {
   const payload = JSON.stringify({ message: 'Hello World!' })
-  const sendNotif2Sub = sub => webpush.sendNotification(sub, payload).catch(err => err.statusCode === 410 ? deregisterSub(user, sub) : err)
-  return Promise.allSettled(user.subscriptions.map(sendNotif2Sub))
-}
-
-function deregisterSub (user, sub) {
-  const es = require('aws-es-client')({
-    id: process.env.ES_ID,
-    token: process.env.ES_SECRET,
-    url: process.env.ES_ENDPOINT
-  })
-  return es.updateByQuery({
-    index: 'users',
-    refresh: true,
-    body: {
-      script: getScript(sub),
-      query: getQuery(user, sub)
-    }
-  })
-}
-
-function getScript (sub) {
   return {
-    lang: 'painless',
-    source: 'ctx._source.subscriptions.remove(ctx._source.subscriptions.indexOf(params.sub))',
-    params: {
-      sub: sub
-    }
-  }
-}
-
-function getQuery (user, sub) {
-  return {
-    bool: {
-      must: {
-        match: {
-          _id: user
-        }
-      },
-      filter: {
-        match: {
-          'subscriptions.endpoint': sub.endpoint
-        }
-      }
-    }
+    user: user.email,
+    pushes: await Promise.allSettled(user.subscriptions.map(sub => webpush.sendNotification(sub, payload)))
   }
 }

--- a/layer/nodejs/push-notif-utils/utils.js
+++ b/layer/nodejs/push-notif-utils/utils.js
@@ -1,5 +1,6 @@
 module.exports = {
   getKeys: require('./get-keys.js'),
   getUsers: require('./get-users.js'),
-  sendNotifications: require('./send-notifications.js')
+  sendNotifications: require('./send-notifications.js'),
+  deregisterSubs: require('./deregister-subs.js')
 }

--- a/layer/nodejs/push-notif-utils/utils.js
+++ b/layer/nodejs/push-notif-utils/utils.js
@@ -1,5 +1,5 @@
 module.exports = {
   getKeys: require('./get-keys.js'),
-  getSubs: require('./get-subs.js'),
+  getUsers: require('./get-users.js'),
   sendNotifications: require('./send-notifications.js')
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "serverless.yml",
   "scripts": {
-    "test": "echo \"No test script defined.\""
+    "test": "echo \"No test script defined.\"",
+    "deploy": "cp -r layer/nodejs/push-notif-utils layer/nodejs/node_modules/push-notif-utils && sls deploy -v && rm -r layer/nodejs/node_modules/push-notif-utils"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Changes description**
Implemented deregistration logic from the `push` api. **Note:** this may be moved later on into an external lambda to decouple the logic from the one of this collection which should be dedicated to pushing notifications only.

**New features**
- _subscription deregistration:_ handling deregistration of dead endpoints after pushing notifications. Designed to first push, then check which endpoints failed and finally do a bulk update of our DB removing all those dead endpoints.

**Updated features**
- _`get-subs`:_ updated utility to return all `users` instead so that we may loop over users to know which user has dead endpoints for their subscriptions