### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,43 @@ on:
       - 'lambdas/**'
       - 'layer/**'
       - 'package.json'
+      - 'docs/**'
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: lambda
+        template: docs/template.md
+      env:
+        ES_ID: ${{ secrets.ES_ID }}
+        ES_SECRET: ${{ secrets.ES_SECRET }}
+        ES_ENDPOINT: ${{ secrets.ES_ENDPOINT }}
+        TARGET_EVENT_BUS_ARN: ${{ secrets.EB_PUSH_NOTIFS_RESULTS_BUS_ARN }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: generate-docs
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Pull latest commit
+      run: |
+        git config pull.rebase false
+        git pull
     - name: Install dependencies
       run: npm i
     - name: serverless check

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,29 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/push-notification-lambdas)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/push-notification-lambdas?color=blue)
+
+**GitHub Actions workflows status**
+
+[![](https://img.shields.io/github/workflow/status/kaskadi/push-notification-lambdas/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/push-notification-lambdas/actions?query=workflow%3Adeploy)
+[![](https://img.shields.io/github/workflow/status/kaskadi/push-notification-lambdas/build?label=build&logo=mocha)](https://github.com/kaskadi/push-notification-lambdas/actions?query=workflow%3Abuild)
+[![](https://img.shields.io/github/workflow/status/kaskadi/push-notification-lambdas/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/push-notification-lambdas/actions?query=workflow%3Asyntax-check)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/push-notification-lambdas?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/push-notification-lambdas)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/push-notification-lambdas?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/push-notification-lambdas)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/push-notification-lambdas?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/push-notification-lambdas)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/push-notification-lambdas?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/push-notification-lambdas/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+<!-- You can customize this template as you'd like! -->

--- a/layer/serverless.yml
+++ b/layer/serverless.yml
@@ -1,6 +1,6 @@
 path: layer
 name: ${self:service.name}-layer
-description": Layer for ${self:service.name}
+description: Layer for ${self:service.name}
 compatibleRuntimes:
   - nodejs10.x
   - nodejs12.x


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` GitHub action inside of `deploy` workflow` and `docs/template.md` as template.

**New features**
- _documentation template:_ added documentation template under `docs/template.md`

**Updated features**
- _`deploy` workflow:_ added `generate-docs` job inside of `deploy` workflow. This uses `action-generate-docs` action as well as `docs/template.md` as template
- _config file:_ fixed field name in layer config file